### PR TITLE
Add revoke access token functionality

### DIFF
--- a/oura/auth.py
+++ b/oura/auth.py
@@ -58,6 +58,7 @@ class OuraOAuth2Client:
 
 class OAuthRequestHandler:
     TOKEN_BASE_URL = "https://api.ouraring.com/oauth/token"
+    TOKEN_REVOKE_URL = "https://api.ouraring.com/oauth/revoke"
 
     def __init__(
         self,
@@ -84,16 +85,15 @@ class OAuthRequestHandler:
             token_updater=refresh_callback,
         )
 
-    def make_request(self, url):
-        method = "GET"
+    def make_request(self, url, method="GET"):
         response = self._session.request(method, url)
         if response.status_code == 401:
             self._refresh_token()
             response = self._session.request(method, url)
         return response
 
-    def make_request_v2(self, url):
-        return self.make_request(url)
+    def make_request_v2(self, url, method="GET"):
+        return self.make_request(url, method)
 
     def _refresh_token(self):
         token = self._session.refresh_token(
@@ -106,14 +106,24 @@ class OAuthRequestHandler:
 
         return token
 
+    def revoke_token(self):
+        return self._session.request("POST", self.TOKEN_REVOKE_URL)
+
 
 class PersonalRequestHandler:
+    TOKEN_REVOKE_URL = "https://api.ouraring.com/oauth/revoke"
+
     def __init__(self, personal_access_token):
         self.personal_access_token = personal_access_token
 
-    def make_request(self, url):
-        return requests.get(url, params={"access_token": self.personal_access_token})
+    def make_request(self, url, method="GET"):
+        requests_method = requests.post if method == "POST" else requests.get
+        return requests_method(url, params={"access_token": self.personal_access_token})
 
-    def make_request_v2(self, url):
+    def make_request_v2(self, url, method="GET"):
+        requests_method = requests.post if method == "POST" else requests.get
         headers = {"Authorization": f"Bearer {self.personal_access_token}"}
-        return requests.get(url, headers=headers)
+        return requests_method(url, headers=headers)
+
+    def revoke_token(self):
+        return self.make_request_v2(self.TOKEN_REVOKE_URL, "POST")

--- a/oura/v2/client.py
+++ b/oura/v2/client.py
@@ -95,3 +95,9 @@ class OuraClientV2:
         qs = "&".join([f"{k}={v}" for k, v in params.items()])
         url = f"{url}?{qs}" if qs != "" else url
         return url
+
+    def revoke_token(self):
+        response = self._auth_handler.revoke_token()
+        exceptions.detect_and_raise_error(response)
+        payload = json.loads(response.content.decode("utf8"))
+        return payload


### PR DESCRIPTION
[Oura docs](https://cloud.ouraring.com/docs/authentication) mentions revoke access functionality, so in this PR I add this functionality to client

Reasoning for some changes:
1. New optional parameter `method` for `make_request` and `make_request_v2` methods
Since `/oauth/revoke` endpoint requires POST request (405 Method Not Allowed otherwise), I decided to make `method` as optional parameter instead of duplicating code for post request in separate method.
2. Changes to `OAuthRequestHandler.make_request`
Although I don't use `make_request` when revoking token with `OAuthRequestHandler`, I decided to change it anyway, so both request handlers have the same methods signatures.
3. Adding `revoke_token` functionality to `OuraClientV2` instead of `OuraOAuth2Client`
Although endpoint for revoking token is `/oauth/revoke` which is similar to `/oauth/token` and `/oauth/authorize` used by `OuraOAuth2Client`, I decided to add it to `OuraClientV2`, because the latter already has access token, and method invocation does not require any extra parameters, whereas `OuraOAuth2Client` doesn't store user token and we would have to pass it to method.