### PR TITLE
Add missing endpoints

### DIFF
--- a/oura/v2/client.py
+++ b/oura/v2/client.py
@@ -50,18 +50,41 @@ class OuraClientV2:
         # start_date default to end_date - 1 day
         return self._get_summary(start_date, end_date, next_token, "daily_activity")
 
+    def daily_readiness(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "daily_readiness")
+
+    def daily_sleep(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "daily_sleep")
+
+    def daily_spo2(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "daily_spo2")
+
+    def daily_stress(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "daily_stress")
+
+    def enhanced_tag(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "enhanced_tag")
+
     def heartrate(self, start_date=None, end_date=None, next_token=None):
         return self._get_summary(start_date, end_date, next_token, "heartrate")
 
     def personal_info(self):
-        url = f"{self.API_ENDPOINT}/personal_info"
-        return self._make_request(url)
+        return self._get_summary(None, None, None, "personal_info")
+
+    def rest_mode_period(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "rest_mode_period")
+
+    def ring_configuration(self, next_token=None):
+        return self._get_summary(None, None, next_token, "ring_configuration")
 
     def session(self, start_date=None, end_date=None, next_token=None):
         return self._get_summary(start_date, end_date, next_token, "session")
 
-    def tags(self, start_date=None, end_date=None, next_token=None):
-        return self._get_summary(start_date, end_date, next_token, "tag")
+    def sleep(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "sleep")
+
+    def sleep_time(self, start_date=None, end_date=None, next_token=None):
+        return self._get_summary(start_date, end_date, next_token, "sleep_time")
 
     def workouts(self, start_date=None, end_date=None, next_token=None):
         return self._get_summary(start_date, end_date, next_token, "workout")


### PR DESCRIPTION
There are plenty of endpoints described in [Oura API docs](https://cloud.ouraring.com/v2/docs), but only a few of them in Client.
So here I add all of them. (Although I didn't add webhook setup endpoints and endpoints to retrieve single record of some type e.g. `daily_activity/{document_id}`)

Also I removed `tags` method, since `/tag` endpoint is deprecated in favor of `/enhanced_tag`

Also I updated `personal_info` to be more consistent with the rest.